### PR TITLE
Make path to Dockerfile dynamic

### DIFF
--- a/scripts/run_docker_buildroot.sh
+++ b/scripts/run_docker_buildroot.sh
@@ -13,7 +13,7 @@ if [ $(id -u) -eq 0 ]; then
 fi
 
 
-docker build --quiet --tag "buildroot-buildenv-$(git rev-parse --short=12 HEAD)" docker/
+docker build --quiet --tag "buildroot-buildenv-$(git rev-parse --short=12 HEAD)" $(dirname "$0")/../docker/
 
 # build must run as a normal user
 # Overwrite $HOME to allow for buildroot ccache to work somewhat seamlessly


### PR DESCRIPTION
For instances when this repo may be used as a submodule in another project, making the path to this repo's "docker/Dockerfile" easy to access when calling the script from any higher directory.

This has been heavily tested with the TS-TPC-7990 balloon pump demo work.