### PR TITLE
Add LVGL, lv_drivers, and TS-7100-Z UI demo using LVGL

### DIFF
--- a/technologic/Config.in
+++ b/technologic/Config.in
@@ -21,6 +21,7 @@ endchoice
 
 menu "Light and Versatile Graphics Library (LVGL)"
 	source "$BR2_EXTERNAL_TECHNOLOGIC_PATH/package/liblvgl/Config.in"
+	source "$BR2_EXTERNAL_TECHNOLOGIC_PATH/package/lv_drivers/Config.in"
 endmenu
 
 menu "Misc Tools for Device Support"

--- a/technologic/Config.in
+++ b/technologic/Config.in
@@ -24,6 +24,8 @@ menu "Light and Versatile Graphics Library (LVGL)"
 	source "$BR2_EXTERNAL_TECHNOLOGIC_PATH/package/lv_drivers/Config.in"
 endmenu
 
+source "$BR2_EXTERNAL_TECHNOLOGIC_PATH/package/ts7100z-lvgl-ui-demo/Config.in"
+
 menu "Misc Tools for Device Support"
 	source "$BR2_EXTERNAL_TECHNOLOGIC_PATH/package/growpart/Config.in"
 	source "$BR2_EXTERNAL_TECHNOLOGIC_PATH/package/idleinject/Config.in"

--- a/technologic/Config.in
+++ b/technologic/Config.in
@@ -19,6 +19,10 @@ choice
 	source "$BR2_EXTERNAL_TECHNOLOGIC_PATH/package/ts7820-utils/Config.in"
 endchoice
 
+menu "Light and Versatile Graphics Library (LVGL)"
+	source "$BR2_EXTERNAL_TECHNOLOGIC_PATH/package/liblvgl/Config.in"
+endmenu
+
 menu "Misc Tools for Device Support"
 	source "$BR2_EXTERNAL_TECHNOLOGIC_PATH/package/growpart/Config.in"
 	source "$BR2_EXTERNAL_TECHNOLOGIC_PATH/package/idleinject/Config.in"

--- a/technologic/board/ts7100/overlay/etc/init.d/S99lvgl-demo
+++ b/technologic/board/ts7100/overlay/etc/init.d/S99lvgl-demo
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+case "$1" in
+        start)
+                echo "Starting LVGL Demo"
+		echo 0 > /sys/class/graphics/fbcon/cursor_blink
+                start-stop-daemon -S -b -q -m -p /var/run/lvgl-demo.pid -x /usr/bin/ts7100z-lvgl-ui-demo
+                exit $?
+                ;;
+
+        stop)
+                exit 0
+                ;;
+
+        restart)
+		exit 0
+                ;;
+
+        *)
+                echo "Usage: $0 {start|stop|restart}"
+                exit 1
+esac

--- a/technologic/board/ts7100/overlay/etc/udev/rules.d/99-resistive-touchscreen.rules
+++ b/technologic/board/ts7100/overlay/etc/udev/rules.d/99-resistive-touchscreen.rules
@@ -1,0 +1,4 @@
+# TS-7100-Z
+# Note that, this specifically matches the device and SPI bus.
+# If the SPI bus ever changes for some reason, this will no longer match
+ACTION=="add|change", KERNEL=="event[0-9]*", ATTRS{name}=="ADS7846 Touchscreen", ATTRS{phys}=="spi5.0/input[0-9]*", ENV{LIBINPUT_CALIBRATION_MATRIX}="1.14360133 0.02219533 -0.06783767 -0.01262267 -1.13283667 1.047116"

--- a/technologic/package/liblvgl/Config.in
+++ b/technologic/package/liblvgl/Config.in
@@ -1,0 +1,20 @@
+config BR2_PACKAGE_LIBLVGL
+	bool "liblvgl"
+	help
+	  Build and install libraries to support the
+	  Light and Versatile Graphics Library (LVGL). This requires
+	  an externally provided lv_conf.h file to handle the build
+	  configuration.
+
+config BR2_PACKAGE_LIBLVGL_LVCONF
+	string "Path to lv_conf.h to build against"
+	depends on BR2_PACKAGE_LIBLVGL
+	help
+	  Path to the lv_conf.h file used to configure the LVGL build.
+
+	  Note that this is required in order to build a useful LVGL
+	  library!
+
+	  The path can be a URL beginning with ftp://, http://,
+	  or https://. Otherwise, it will be assumed to be a file on
+	  disk and will be copied from that path.

--- a/technologic/package/liblvgl/liblvgl.mk
+++ b/technologic/package/liblvgl/liblvgl.mk
@@ -1,0 +1,33 @@
+################################################################################
+#
+# liblvgl
+#
+################################################################################
+
+LIBLVGL_VERSION = v8.3.9
+LIBLVGL_SITE = $(call github,lvgl,lvgl,$(LIBLVGL_VERSION))
+LIBLVGL_INSTALL_STAGING = YES
+LIBLVGL_LICENSE = MIT
+LIBLVGL_LICENSE_FILES = LICENCE.txt
+
+# Copy lv_conf.h to the download dir
+# If from a remote URL, the EXTRA_DOWNLOADS variable can easily be used.
+# If a local path, extract that path and just copy it manually
+LIBLVGL_LVCONF = $(call qstrip,$(BR2_PACKAGE_LIBLVGL_LVCONF))
+LIBLVGL_LVCONF_BN = $(notdir $(LIBLVGL_LVCONF))
+LIBLVGL_EXTRA_DOWNLOADS = $(filter ftp://% http://% https://%,$(LIBLVGL_LVCONF))
+ifeq ($(LIBLVGL_EXTRA_DOWNLOADS),)
+ifneq ($(LIBLVGL_LVCONF),)
+define LIBLVGL_COPY_LVCONF_TO_DL_DIR
+	cp "$(LIBLVGL_LVCONF)" "$(LIBLVGL_DL_DIR)"
+endef
+LIBLVGL_POST_DOWNLOAD_HOOKS += LIBLVGL_COPY_LVCONF_TO_DL_DIR
+endif
+endif
+
+define LIBLVGL_COPY_LVCONF_TO_BUILD_DIR
+	cp "$(LIBLVGL_DL_DIR)/$(LIBLVGL_LVCONF_BN)" "$(@D)/lv_conf.h"
+endef
+LIBLVGL_POST_EXTRACT_HOOKS += LIBLVGL_COPY_LVCONF_TO_BUILD_DIR
+
+$(eval $(cmake-package))

--- a/technologic/package/lv_drivers/Config.in
+++ b/technologic/package/lv_drivers/Config.in
@@ -1,0 +1,30 @@
+config BR2_PACKAGE_LV_DRIVERS
+	bool "lv_drivers"
+	depends on BR2_PACKAGE_LIBLVGL
+	help
+	  Drivers package for LVGL. This provides a number of interface
+	  routines for things such as libinput, fbdev, wayland, etc. It
+	  builds and installs libraries to the target and provides
+	  headers and libraries for compilation of other packages.
+
+	  This requires LVGL to be enabled and built. This will have
+	  access to lv_conf.h already from LVGL. Additionally, another
+	  configuration file, lv_drv_conf.h, is needed by lv_drivers in
+	  order to configure the build properly.
+
+comment "lv_drivers needs liblvgl"
+	depends on !BR2_PACKAGE_LIBLVGL
+
+config BR2_PACKAGE_LV_DRIVERS_LVDRVCONF
+	string "Path to lv_drv_conf.h to build against"
+	depends on BR2_PACKAGE_LV_DRIVERS
+	help
+	  Path to the lv_drv_conf.h file used to configure the
+	  lv_drviers build.
+
+	  Note that this is required in order to build a useful
+	  lv_drivers library!
+
+	  The path can be a URL beginning with ftp://, http://,
+	  or https://. Otherwise, it will be assumed to be a file on
+	  disk and will be copied from that path.

--- a/technologic/package/lv_drivers/lv_drivers.mk
+++ b/technologic/package/lv_drivers/lv_drivers.mk
@@ -1,0 +1,41 @@
+################################################################################
+#
+# lv_drivers
+#
+################################################################################
+
+LV_DRIVERS_VERSION = v8.3.0
+LV_DRIVERS_SITE = $(call github,lvgl,lv_drivers,$(LV_DRIVERS_VERSION))
+LV_DRIVERS_INSTALL_STAGING = YES
+LV_DRIVERS_CONF_OPTS = -DCMAKE_C_FLAGS="-I$(STAGING_DIR)/usr/include/lvgl/" -DCMAKE_CXX_FLAGS="-I$(STAGING_DIR)/usr/include/lvgl/"
+LV_DRIVERS_LICENSE = MIT
+LV_DRIVERS_LICENSE_FILES = LICENSE
+# Note that there may be other dependencies, however those are driven by
+# lv_drv_conf.h options and its not easy to specify those without either
+# directly parsing the conf file OR using buildroot options to generate
+# the conf file.
+#
+# For now, just assume its use will need libinput
+LV_DRIVERS_DEPENDENCIES = liblvgl libinput
+
+# Copy lv_drv_conf.h to the download dir
+# If from a remote URL, the EXTRA_DOWNLOADS variable can easily be used.
+# If a local path, extract that path and just copy it manually
+LV_DRIVERS_LVDRVCONF = $(call qstrip,$(BR2_PACKAGE_LV_DRIVERS_LVDRVCONF))
+LV_DRIVERS_LVDRVCONF_BN = $(notdir $(LV_DRIVERS_LVDRVCONF))
+LV_DRIVERS_EXTRA_DOWNLOADS = $(filter ftp://% http://% https://%,$(LV_DRIVERS_LVDRVCONF))
+ifeq ($(LV_DRIVERS_EXTRA_DOWNLOADS),)
+ifneq ($(LV_DRIVERS_LVDRVCONF),)
+define LV_DRIVERS_COPY_LVDRVCONF_TO_DL_DIR
+	cp "$(LV_DRIVERS_LVDRVCONF)" "$(LV_DRIVERS_DL_DIR)"
+endef
+LV_DRIVERS_POST_DOWNLOAD_HOOKS += LV_DRIVERS_COPY_LVDRVCONF_TO_DL_DIR
+endif
+endif
+
+define LV_DRIVERS_COPY_LVDRVCONF_TO_BUILD_DIR
+	cp "$(LV_DRIVERS_DL_DIR)/$(LV_DRIVERS_LVDRVCONF_BN)" "$(@D)/../lv_drv_conf.h"
+endef
+LV_DRIVERS_POST_EXTRACT_HOOKS += LV_DRIVERS_COPY_LVDRVCONF_TO_BUILD_DIR
+
+$(eval $(cmake-package))

--- a/technologic/package/ts7100z-lvgl-ui-demo/Config.in
+++ b/technologic/package/ts7100z-lvgl-ui-demo/Config.in
@@ -1,0 +1,21 @@
+config BR2_PACKAGE_TS7100Z_LVGL_UI_DEMO
+	bool "ts7100z-lvgl-ui-demo"
+	depends on BR2_PACKAGE_LIBLVGL
+	depends on BR2_PACKAGE_LV_DRIVERS
+	select BR2_PACKAGE_LIBINPUT
+	select BR2_PACKAGE_LIBGPIOD
+	select BR2_PACKAGE_LIBIIO
+	help
+	  Simple graphical demo for TS-7100-Z using LVGL
+
+	  Includes the splash-screen image for I/O location reference;
+	  control of the two relays; control of the 3 high-voltage,
+	  low-side switches; feedback of the input path of those same
+	  low-side switches via emulated LEDs; control of the 1
+	  high-voltage, high-side switch; and a meter display of the
+	  4 0-12 V ADC inputs.
+
+	  libgpiod and libiiod are used for GPIO and ADC control.
+
+comment "ts7100z-lvgl-ui-demo needs liblvgl and lv_drivers"
+	depends on !BR2_PACKAGE_LV_DRIVERS

--- a/technologic/package/ts7100z-lvgl-ui-demo/ts7100z-lvgl-ui-demo.hash
+++ b/technologic/package/ts7100z-lvgl-ui-demo/ts7100z-lvgl-ui-demo.hash
@@ -1,0 +1,3 @@
+# Locally computed:
+sha256  d9c98d1986bd1ddeb5cae92d25a6b9a7e5a56dc67fb55b5087ed9e86e5f6fa89  ts7100z-lvgl-ui-demo-v1.0.0.tar.gz
+sha256  bd271650c650f5cdfaecb61539ceaeda1b7271cc3cf9642dc9873eaa4e261d96  LICENSE

--- a/technologic/package/ts7100z-lvgl-ui-demo/ts7100z-lvgl-ui-demo.mk
+++ b/technologic/package/ts7100z-lvgl-ui-demo/ts7100z-lvgl-ui-demo.mk
@@ -1,0 +1,14 @@
+################################################################################
+#
+# ts7100z-lvgl-ui-demo
+#
+################################################################################
+
+TS7100Z_LVGL_UI_DEMO_VERSION = v1.0.0
+TS7100Z_LVGL_UI_DEMO_SITE = $(call github,embeddedTS,ts7100z-lvgl-ui-demo,$(TS7100Z_LVGL_UI_DEMO_VERSION))
+TS7100Z_LVGL_UI_DEMO_CONF_OPTS = -DCMAKE_C_FLAGS="-I$(STAGING_DIR)/usr/include/lvgl/" -DCMAKE_CXX_FLAGS="-I$(STAGING_DIR)/usr/include/lvgl/"
+TS7100Z_LVGL_UI_DEMO_LICENSE = BSD-2-Clause
+TS7100Z_LVGL_UI_DEMO_LICENSE_FILES = LICENSE
+TS7100Z_LVGL_UI_DEMO_DEPENDENCIES = libiio libgpiod liblvgl lv_drivers
+
+$(eval $(cmake-package))


### PR DESCRIPTION
This adds support for (but does not roll out an implementation, see below) the simple UI demo meant for TS-7100-Z touchscreen using LVGL, a lightweight graphics library. Expect a future PR for actually rolling this out.

The TS-7100-Z Buildroot defconfig needs some updates to support the latest kernel. Adding that in this PR is out of scope.

Both liblvgl and lv_drivers are set up to build and will (in most cases) default to building shared libraries.

The actual demo application includes a startup script to auto-launch once the system has fully booted.