### PR TITLE
ts7250v3-usbprod: fix boot issue on older U-Boot builds

### DIFF
--- a/technologic/board/ts7250v3-usbprod/scripts/boot.source
+++ b/technologic/board/ts7250v3-usbprod/scripts/boot.source
@@ -1,6 +1,9 @@
 # mkimage -A arm -T script -C none -n 'boot' -d boot.source boot.scr
 setenv bootargs "console=${console} ro init=/sbin/init;"
 
+env set fdt_high 0xffffffff
+env set initrd_high 0xffffffff
+
 load ${devtype} ${devnum}:${distro_bootpart} ${kernel_addr_r} ${prefix}zImage \
 && load ${devtype} ${devnum}:${distro_bootpart} ${fdt_addr_r} ${prefix}${fdtfile} \
 && load ${devtype} ${devnum}:${distro_bootpart} ${ramdisk_addr_r} ${prefix}rootfs.cpio.gz \


### PR DESCRIPTION
Newer builds set up the initrd_ and fdt_ high addresses to tell the kernel not to relocate them and instead use them where they were loaded. Something with the relocation process causes data to get clobbered and therefore the kernel to hang.